### PR TITLE
Fix one too many sql query

### DIFF
--- a/src/GeekLearning.DataTables.EntityFrameworkCore/DataTableContext.cs
+++ b/src/GeekLearning.DataTables.EntityFrameworkCore/DataTableContext.cs
@@ -28,19 +28,23 @@
 
 		public IQueryable<TData> Query { get; set; }
 
+		public IQueryable<TData> OrderedQuery { get; set; }
+
 		public IQueryable<TData> FilteredQuery { get; set; }
 
-		public IQueryable<TData> PaginatedQuery { get; set; }
+              public IQueryable<TData> PaginatedQuery { get; set; }
 
 		public async Task<DataTableResult<TDataViewModel>> CreateResultAsync<TDataViewModel>(IEnumerable<TDataViewModel> viewModels)
 		{
             var data = viewModels.ToList();
+            var recordsTotal = Query != null ? await Query.CountAsync() : data.Count;
+            var nothingFiltered = FilteredQuery == OrderedQuery;
 
             return new DataTableResult<TDataViewModel>
 			{
 				Data = data,
-				RecordsTotal = Query != null ? await Query.CountAsync() : data.Count,
-				RecordsFiltered = FilteredQuery != null ? await FilteredQuery.CountAsync() : data.Count,
+				RecordsTotal = recordsTotal,
+                            RecordsFiltered = nothingFiltered ? recordsTotal : await FilteredQuery?.CountAsync(),
 				Draw = Parameters.Draw
 			};
 		}

--- a/src/GeekLearning.DataTables/DataTableExtensions.cs
+++ b/src/GeekLearning.DataTables/DataTableExtensions.cs
@@ -12,9 +12,9 @@
                             throw new InvalidOperationException("A DataTable resolver is required to paginate.");
                      }
 
-                     context.Query = query;
-                     context.FilteredQuery = context.Query
-                         .Order(context.Parameters.Order, context.Resolver)
+                     context.OrderedQuery = context.Query
+                            .Order(context.Parameters.Order, context.Resolver);
+                     context.FilteredQuery = context.OrderedQuery
                          .Search(context.Parameters.Search, context.Resolver);
                      context.PaginatedQuery = context.FilteredQuery
                          .Skip(context.Parameters.Start)

--- a/src/GeekLearning.DataTables/IDataTableContext.cs
+++ b/src/GeekLearning.DataTables/IDataTableContext.cs
@@ -18,7 +18,9 @@
 
 		IQueryable<TData> Query { get; set; }
 
-		IQueryable<TData> FilteredQuery { get; set; }
+              IQueryable<TData> OrderedQuery { get; set; }
+
+              IQueryable<TData> FilteredQuery { get; set; }
 
 		IQueryable<TData> PaginatedQuery { get; set; }
 


### PR DESCRIPTION
If you have no filtered query, ie. no search, the CountAsync request is made twice, sql profiler would indeed show twice the same request. 
```
SELECT COUNT(*)
FROM [Table] AS [i]
```

The suggested solution here checks if the search method returned a new query or not by comparing the two references. If not, then the above `recordsTotal` variable is reused.