### PR TITLE
Possibility to filter on multiple string properties 

### DIFF
--- a/src/GeekLearning.DataTables/DataTableExtensions.cs
+++ b/src/GeekLearning.DataTables/DataTableExtensions.cs
@@ -11,7 +11,7 @@
                      {
                             throw new InvalidOperationException("A DataTable resolver is required to paginate.");
                      }
-
+                     context.Query = query;
                      context.OrderedQuery = context.Query
                             .Order(context.Parameters.Order, context.Resolver);
                      context.FilteredQuery = context.OrderedQuery
@@ -60,7 +60,7 @@
 
                      if (!string.IsNullOrWhiteSpace(searchParameters.Value))
                      {
-                            return query.DynamicWhere(resolver.SearchableColumn, searchParameters.Value);
+                            return query.DynamicWhere(resolver.SearchableColumns, searchParameters.Value);
                      }
 
                      return query;

--- a/src/GeekLearning.DataTables/DataTableExtensions.cs
+++ b/src/GeekLearning.DataTables/DataTableExtensions.cs
@@ -11,6 +11,7 @@
                      {
                             throw new InvalidOperationException("A DataTable resolver is required to paginate.");
                      }
+
                      context.Query = query;
                      context.OrderedQuery = context.Query
                             .Order(context.Parameters.Order, context.Resolver);

--- a/src/GeekLearning.DataTables/DataTableResolver.cs
+++ b/src/GeekLearning.DataTables/DataTableResolver.cs
@@ -1,12 +1,24 @@
 ﻿namespace GeekLearning.DataTables
 {
     using System;
+    using System.Linq;
 
     [AttributeUsage(AttributeTargets.Class)]
 	public class DataTableResolver : Attribute
 	{
-		public string SearchableColumn { get; set; }
-
-		public string[] OrderableColumns { get; set; }
+        public string SearchableColumn
+        {
+            get { return this.SearchableColumns?.FirstOrDefault(); }
+            set
+            {
+                if (SearchableColumns == null)
+                {
+                    SearchableColumns = new string[1];
+                }
+                SearchableColumns[0] = value;
+            }
+        }
+        public string[] SearchableColumns { get; set; }
+        public string[] OrderableColumns { get; set; }
 	}
 }

--- a/src/GeekLearning.DataTables/GeekLearning.DataTables.csproj
+++ b/src/GeekLearning.DataTables/GeekLearning.DataTables.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LINQKit.Core" Version="1.1.15" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Query can filter on multiple properties. 
Usage is: 
` [DataTableResolver(OrderableColumns = new[] { nameof(C1), nameof(C2) }, SearchableColumns = new[] { nameof(C1), nameof(C2) })]`
However, must be string properties as before. 
NB: for the purpose of combining or predicates, linqkit library is being used.